### PR TITLE
Add concurrencly in service BoardOfDirector

### DIFF
--- a/src/main/doc/diagrama entidad relacion/diagramaDeSecuenciaCRUD.md
+++ b/src/main/doc/diagrama entidad relacion/diagramaDeSecuenciaCRUD.md
@@ -1,0 +1,46 @@
+## BoardOfDirector
+<br>
+
+```mermaid
+
+sequenceDiagram
+autonumber
+participant Client
+participant BoardOfDirectorController
+participant BoardOfDirectorCrudServiceImpl
+participant CorporateClientValidationService
+participant BoardOfDirectorRepository
+participant MessageService
+
+    Client ->> BoardOfDirectorController: POST /board_of_directors
+    BoardOfDirectorController ->> BoardOfDirectorCrudServiceImpl: create(request)
+    activate BoardOfDirectorCrudServiceImpl
+
+    BoardOfDirectorCrudServiceImpl ->> BoardOfDirectorCrudServiceImpl: toEntity(request)
+    activate BoardOfDirectorCrudServiceImpl
+
+    BoardOfDirectorCrudServiceImpl ->> CorporateClientValidationService: validateCorporateClientExists(corporateClient)
+    activate CorporateClientValidationService
+    CorporateClientValidationService -->> BoardOfDirectorCrudServiceImpl: corporateClient
+    deactivate CorporateClientValidationService
+
+    par [Async Operations]
+        BoardOfDirectorCrudServiceImpl ->> BoardOfDirectorRepository: save(boardOfDirector)
+        activate BoardOfDirectorRepository
+        BoardOfDirectorRepository -->> BoardOfDirectorCrudServiceImpl: savedBoardOfDirector
+        deactivate BoardOfDirectorRepository
+    end
+
+    BoardOfDirectorCrudServiceImpl ->> BoardOfDirectorCrudServiceImpl: toResponseDto(savedBoardOfDirector)
+    deactivate BoardOfDirectorCrudServiceImpl
+    BoardOfDirectorCrudServiceImpl -->> BoardOfDirectorController: BoardOfDirectorCrudResponseDto
+    deactivate BoardOfDirectorCrudServiceImpl
+
+    BoardOfDirectorController ->> MessageService: getMessage("boardOfDirector.controller.create.successfully")
+    activate MessageService
+    MessageService -->> BoardOfDirectorController: successMessage
+    deactivate MessageService
+
+    BoardOfDirectorController -->> Client: ApiCustomResponse<BoardOfDirectorCrudResponseDto>
+
+```

--- a/src/main/java/com/sied/clients/controller/boardOfDirector/BoardOfDirectorController.java
+++ b/src/main/java/com/sied/clients/controller/boardOfDirector/BoardOfDirectorController.java
@@ -14,17 +14,35 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Controlador REST para la gestión de la entidad BoardOfDirector.
+ * Proporciona endpoints para crear, obtener, actualizar y eliminar registros
+ * de miembros de la junta directiva de manera asíncrona.
+ */
 @RequestMapping(ApiVersion.V3 + "/board_of_directors")
 @RestController
 public class BoardOfDirectorController {
+
     private final BoardOfDirectorCrudService boardOfDirectorCrudService;
     private final MessageService messageService;
 
+    /**
+     * Constructor para la clase BoardOfDirectorController.
+     *
+     * @param boardOfDirectorCrudService Servicio para las operaciones CRUD de BoardOfDirector.
+     * @param messageService Servicio para mensajes personalizados en las respuestas.
+     */
     public BoardOfDirectorController(BoardOfDirectorCrudService boardOfDirectorCrudService, MessageService messageService) {
         this.boardOfDirectorCrudService = boardOfDirectorCrudService;
         this.messageService = messageService;
     }
 
+    /**
+     * Crea un nuevo registro de BoardOfDirector.
+     *
+     * @param request DTO que contiene los datos del BoardOfDirector a crear.
+     * @return Un CompletableFuture con la respuesta HTTP, incluyendo el DTO del BoardOfDirector creado.
+     */
     @PostMapping
     public CompletableFuture<ResponseEntity<ApiCustomResponse<BoardOfDirectorCrudResponseDto>>> create(
             @Validated @RequestBody BoardOfDirectorCrudRequestDto request
@@ -41,6 +59,12 @@ public class BoardOfDirectorController {
         );
     }
 
+    /**
+     * Obtiene un BoardOfDirector por su ID.
+     *
+     * @param id ID del BoardOfDirector a obtener.
+     * @return Un CompletableFuture con la respuesta HTTP, incluyendo el DTO del BoardOfDirector obtenido.
+     */
     @GetMapping("/{id}")
     public CompletableFuture<ResponseEntity<ApiCustomResponse<BoardOfDirectorCrudResponseDto>>> get(
             @PathVariable Long id
@@ -57,6 +81,13 @@ public class BoardOfDirectorController {
         );
     }
 
+    /**
+     * Obtiene una lista paginada de todos los BoardOfDirector.
+     *
+     * @param offset Índice de inicio para la paginación.
+     * @param limit Cantidad máxima de registros a devolver.
+     * @return Un CompletableFuture con la respuesta HTTP, incluyendo una lista paginada de BoardOfDirector.
+     */
     @GetMapping
     public CompletableFuture<ResponseEntity<ApiCustomResponse<PaginatedResponse<BoardOfDirectorCrudResponseDto>>>> getAll(
             @RequestParam(defaultValue = "0") int offset,
@@ -74,6 +105,12 @@ public class BoardOfDirectorController {
         );
     }
 
+    /**
+     * Actualiza un registro de BoardOfDirector.
+     *
+     * @param request DTO que contiene los datos actualizados del BoardOfDirector.
+     * @return Un CompletableFuture con la respuesta HTTP, incluyendo el DTO del BoardOfDirector actualizado.
+     */
     @PutMapping
     public CompletableFuture<ResponseEntity<ApiCustomResponse<BoardOfDirectorCrudResponseDto>>> update(
             @Validated @RequestBody BoardOfDirectorCrudUpdateRequestDto request
@@ -90,6 +127,12 @@ public class BoardOfDirectorController {
         );
     }
 
+    /**
+     * Elimina un BoardOfDirector por su ID.
+     *
+     * @param id ID del BoardOfDirector a eliminar.
+     * @return Un CompletableFuture con la respuesta HTTP que indica el éxito de la operación.
+     */
     @DeleteMapping("/{id}")
     public CompletableFuture<ResponseEntity<ApiCustomResponse<Void>>> delete(
             @PathVariable Long id

--- a/src/main/java/com/sied/clients/repository/boardOfDirector/BoardOfDirectorRepository.java
+++ b/src/main/java/com/sied/clients/repository/boardOfDirector/BoardOfDirectorRepository.java
@@ -4,6 +4,11 @@ import com.sied.clients.entity.boardOfDirector.BoardOfDirector;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+/**
+ * Repositorio para la entidad BoardOfDirector.
+ * Proporciona métodos CRUD básicos para interactuar con la base de datos a través de JpaRepository.
+ * Este repositorio hereda las funcionalidades estándar de JpaRepository, como guardar, buscar, actualizar y eliminar registros.
+ */
 @Repository
 public interface BoardOfDirectorRepository extends JpaRepository<BoardOfDirector, Long> {
 }

--- a/src/main/java/com/sied/clients/service/boardOfDirector/BoardOfDirectorCrudService.java
+++ b/src/main/java/com/sied/clients/service/boardOfDirector/BoardOfDirectorCrudService.java
@@ -6,14 +6,51 @@ import com.sied.clients.dto.boardOfDirector.request.BoardOfDirectorCrudUpdateReq
 import com.sied.clients.dto.boardOfDirector.response.BoardOfDirectorCrudResponseDto;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Interfaz para el servicio CRUD de la entidad BoardOfDirector.
+ * Define los métodos para crear, obtener, actualizar y eliminar registros de miembros de la junta directiva.
+ * Todas las operaciones se ejecutan de manera asíncrona mediante CompletableFuture.
+ */
 public interface BoardOfDirectorCrudService {
+
+    /**
+     * Crea un nuevo registro de miembro de la junta directiva.
+     *
+     * @param request El DTO que contiene la información del miembro de la junta directiva a crear.
+     * @return Un CompletableFuture que contiene el DTO de respuesta con los detalles del miembro creado.
+     */
     CompletableFuture<BoardOfDirectorCrudResponseDto> create(BoardOfDirectorCrudRequestDto request);
 
+    /**
+     * Obtiene una lista paginada de todos los miembros de la junta directiva.
+     *
+     * @param offset El índice de inicio para la paginación.
+     * @param limit La cantidad máxima de registros a devolver.
+     * @return Un CompletableFuture que contiene la respuesta paginada con los DTOs de los miembros de la junta.
+     */
     CompletableFuture<PaginatedResponse<BoardOfDirectorCrudResponseDto>> getAll(int offset, int limit);
 
+    /**
+     * Obtiene los detalles de un miembro de la junta directiva específico por su ID.
+     *
+     * @param id El ID del miembro de la junta directiva a obtener.
+     * @return Un CompletableFuture que contiene el DTO de respuesta con los detalles del miembro.
+     */
     CompletableFuture<BoardOfDirectorCrudResponseDto> get(Long id);
 
+    /**
+     * Actualiza los datos de un miembro de la junta directiva.
+     *
+     * @param request El DTO que contiene la información actualizada del miembro de la junta.
+     * @return Un CompletableFuture que contiene el DTO de respuesta con los detalles del miembro actualizado.
+     */
     CompletableFuture<BoardOfDirectorCrudResponseDto> update(BoardOfDirectorCrudUpdateRequestDto request);
 
+    /**
+     * Elimina un miembro de la junta directiva especificado por su ID.
+     *
+     * @param id El ID del miembro de la junta directiva a eliminar.
+     * @return Un CompletableFuture que representa la finalización de la operación de eliminación.
+     */
     CompletableFuture<Void> delete(Long id);
 }

--- a/src/main/java/com/sied/clients/service/boardOfDirector/BoardOfDirectorCrudServiceImpl.java
+++ b/src/main/java/com/sied/clients/service/boardOfDirector/BoardOfDirectorCrudServiceImpl.java
@@ -20,20 +20,31 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Implementación de la interfaz BoardOfDirectorCrudService para operaciones CRUD de la entidad BoardOfDirector.
+ * Proporciona métodos para crear, obtener, actualizar y eliminar registros de miembros de la junta directiva
+ * de manera asíncrona.
+ */
 @Service
 @Slf4j
 public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudService {
     private final BoardOfDirectorRepository boardOfDirectorRepository;
-
     private final String entityName = BoardOfDirector.class.getSimpleName();
     private final String responseDto = BoardOfDirectorCrudResponseDto.class.getSimpleName();
     private final String requestDto = BoardOfDirectorCrudRequestDto.class.getSimpleName();
 
     public final MessageSource messageSource;
     public final MessageService messageService;
-
     private final CorporateClientValidationService corporateClientValidationService;
 
+    /**
+     * Constructor para la clase BoardOfDirectorCrudServiceImpl.
+     *
+     * @param boardOfDirectorRepository Repositorio para realizar operaciones de persistencia en BoardOfDirector.
+     * @param corporateClientValidationService Servicio para validar la existencia de un CorporateClient.
+     * @param messageSource Fuente de mensajes para internacionalización.
+     * @param messageService Servicio para mensajes personalizados en las respuestas.
+     */
     public BoardOfDirectorCrudServiceImpl(BoardOfDirectorRepository boardOfDirectorRepository, CorporateClientValidationService corporateClientValidationService, MessageSource messageSource, MessageService messageService) {
         this.boardOfDirectorRepository = boardOfDirectorRepository;
         this.corporateClientValidationService = corporateClientValidationService;
@@ -41,6 +52,12 @@ public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudServic
         this.messageService = messageService;
     }
 
+    /**
+     * Crea un nuevo registro de BoardOfDirector de manera asíncrona.
+     *
+     * @param request DTO con la información del BoardOfDirector a crear.
+     * @return Un CompletableFuture con el DTO de respuesta del BoardOfDirector creado.
+     */
     @Async
     @Override
     public CompletableFuture<BoardOfDirectorCrudResponseDto> create(BoardOfDirectorCrudRequestDto request) {
@@ -60,6 +77,13 @@ public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudServic
                 });
     }
 
+    /**
+     * Obtiene una lista paginada de todos los BoardOfDirector de manera asíncrona.
+     *
+     * @param offset Índice de inicio para la paginación.
+     * @param limit Cantidad máxima de registros a devolver.
+     * @return Un CompletableFuture con la respuesta paginada de BoardOfDirectorCrudResponseDto.
+     */
     @Async
     @Override
     public CompletableFuture<PaginatedResponse<BoardOfDirectorCrudResponseDto>> getAll(int offset, int limit) {
@@ -74,6 +98,12 @@ public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudServic
         }
     }
 
+    /**
+     * Obtiene un BoardOfDirector por su ID de manera asíncrona.
+     *
+     * @param id ID del BoardOfDirector a obtener.
+     * @return Un CompletableFuture con el DTO de respuesta del BoardOfDirector obtenido.
+     */
     @Async
     @Override
     public CompletableFuture<BoardOfDirectorCrudResponseDto> get(Long id) {
@@ -92,6 +122,12 @@ public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudServic
         });
     }
 
+    /**
+     * Actualiza un BoardOfDirector de manera asíncrona.
+     *
+     * @param request DTO con la información actualizada del BoardOfDirector.
+     * @return Un CompletableFuture con el DTO de respuesta del BoardOfDirector actualizado.
+     */
     @Async
     @Override
     public CompletableFuture<BoardOfDirectorCrudResponseDto> update(BoardOfDirectorCrudUpdateRequestDto request) {
@@ -116,6 +152,12 @@ public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudServic
         });
     }
 
+    /**
+     * Elimina un BoardOfDirector por su ID de manera asíncrona.
+     *
+     * @param id ID del BoardOfDirector a eliminar.
+     * @return Un CompletableFuture que indica la finalización de la operación de eliminación.
+     */
     @Async
     @Override
     public CompletableFuture<Void> delete(Long id) {
@@ -134,6 +176,12 @@ public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudServic
         });
     }
 
+    /**
+     * Convierte un BoardOfDirectorCrudRequestDto en una entidad BoardOfDirector.
+     *
+     * @param request DTO de solicitud de creación.
+     * @return Un CompletableFuture con la entidad BoardOfDirector creada a partir del DTO.
+     */
     private CompletableFuture<BoardOfDirector> toEntity(BoardOfDirectorCrudRequestDto request) {
         log.debug("Mapping {} to {} entity asynchronously", requestDto, entityName);
         return corporateClientValidationService.validateCorporateClientExists(request.getCorporateClient())
@@ -144,6 +192,12 @@ public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudServic
                         .build());
     }
 
+    /**
+     * Convierte un BoardOfDirectorCrudUpdateRequestDto en una entidad BoardOfDirector.
+     *
+     * @param request DTO de solicitud de actualización.
+     * @return Un CompletableFuture con la entidad BoardOfDirector actualizada a partir del DTO.
+     */
     private CompletableFuture<BoardOfDirector> toEntity(BoardOfDirectorCrudUpdateRequestDto request) {
         log.debug("Mapping {} to {} entity asynchronously", requestDto, entityName);
         return corporateClientValidationService.validateCorporateClientExists(request.getCorporateClient())
@@ -154,9 +208,14 @@ public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudServic
                         .build());
     }
 
+    /**
+     * Convierte una entidad BoardOfDirector en un DTO de respuesta BoardOfDirectorCrudResponseDto.
+     *
+     * @param boardOfDirector Entidad BoardOfDirector a convertir.
+     * @return El DTO de respuesta correspondiente.
+     */
     private BoardOfDirectorCrudResponseDto toResponseDto(BoardOfDirector boardOfDirector) {
         log.debug("Mapping {} entity to {} asynchronously", entityName, responseDto);
-
         return BoardOfDirectorCrudResponseDto.builder()
                 .id(boardOfDirector.getId())
                 .corporateClient(boardOfDirector.getCorporateClient())
@@ -168,6 +227,13 @@ public class BoardOfDirectorCrudServiceImpl implements BoardOfDirectorCrudServic
                 .build();
     }
 
+    /**
+     * Maneja excepciones inesperadas lanzadas durante las operaciones CRUD.
+     *
+     * @param action La acción que se estaba realizando cuando ocurrió la excepción.
+     * @param e La excepción lanzada.
+     * @return Una RuntimeException con el mensaje de error y la causa original.
+     */
     private RuntimeException handleUnexpectedException(String action, Exception e) {
         log.error("Error {} {}: {}", action, entityName, e.getMessage());
         return new RuntimeException("Unexpected error while " + action + " " + entityName, e);


### PR DESCRIPTION
feat: Add JavaDoc documentation and Mermaid sequence diagram for BoardOfDirector

- Added detailed JavaDoc to the following classes and interfaces:
  - BoardOfDirectorCrudService: JavaDoc for CRUD operations.
  - BoardOfDirectorCrudServiceImpl: JavaDoc for asynchronous CRUD implementation.
  - BoardOfDirectorController: JavaDoc for REST endpoints handling BoardOfDirector operations.
  - BoardOfDirectorRepository: JavaDoc for basic CRUD operations using JpaRepository.
  
- Created a Mermaid sequence diagram to illustrate the asynchronous flow in BoardOfDirectorCrudServiceImpl, highlighting parallelism in the create operation.

This commit enhances code readability and provides a clear understanding of service interactions for the BoardOfDirector entity.
